### PR TITLE
Remove a warning

### DIFF
--- a/flash.sv
+++ b/flash.sv
@@ -2,8 +2,8 @@ module flash(
   input  logic       clk_100mhz,
   input  logic       nrst,
 
-  inout  logic       miso,
-  inout  logic       mosi,
+  input  logic       miso,
+  output logic       mosi,
   output logic       sclk,
   output logic       wpn,
   output logic       rstn,


### PR DESCRIPTION
The top module defines the `miso` and `mosi` signals as input and output respectively. Thereby, this information should be reflected in the flash controller module where the signals are used.